### PR TITLE
meilleure integration de la page d'instructions

### DIFF
--- a/hardware/doc/Poppy_Humanoid_assembly_instructions.md
+++ b/hardware/doc/Poppy_Humanoid_assembly_instructions.md
@@ -1,79 +1,9 @@
 # Poppy Humanoid assembly instructions
 
+[**English instructions**](en/assemblyGuide.md)
 
 
-## 1- Torso
-
-### [1.1- Trunk assembly](//github.com/poppy-project/Poppy-multiarticulated-torso/blob/master/doc/en/5_DoFs_humanoid_spine.md)
-### [1.2- Right arm assembly](//github.com/poppy-project/Poppy-basic-arms/blob/master/doc/right_arm_assembly_instructions.md)
-### [1.3- Left arm assembly](//github.com/poppy-project/Poppy-basic-arms/blob/master/doc/left_arm_assembly_instructions.md)
-
-### 1.4 Assemble trunk and arms:
-
-- Preparation: 5 min
-- Assembly: 15-20 min
-
-#### 1.4.1 Requirement
-
-![](img/poppy_torso_assembly_BOM.jpg)
-
-**Sub-assemblies:**
-- Trunk
-- Left arm
-- Right arm
-
-**3D printed parts:**
-- Left shoulder
-- right shoulder
-
-**Cables:**
-- 2x 3P 200mm
-
-**Robotis parts:**
-- 48x Bolts M2x3
-
-**Motor configuration:**
-- 1x Alimentation 12V
-- 1x SMPS2Dynamixel
-- 1x USB2Dynamixel or USB2AX
-- A computer...
-
-#### 1.4.2 video instructions:
-Click on the image below to display the video:
-
-[![video](http://img.youtube.com/vi/uDhLIS3vxM4/0.jpg)](http://youtu.be/uDhLIS3vxM4)
+[**Instructions en français**](fr/guideAssemblage.md)
 
 
 
-## [2- Legs assembly](//github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/legs_assembly_instructions.md)
-
-
-## 3- Legs/Torso asembly
-- Preparation: 5 min
-- Assembly: 5-10 min
-
-
-### 3.1- Requirement:
-![](img/poppy_humanoid_assembly_BOM.jpg)
-
-**Sub-assemblies**
-- Legs
-- Torso
-
-**Robotis parts:**
-- 16x Bolts M2.5x4
-
-**Cables:**
-- 1x 3P 140mm
-
-**Motor configuration:**
-- 1x Alimentation 12V
-- 1x SMPS2Dynamixel
-- 1x USB2Dynamixel or USB2AX
-- A computer...
-
-
-### 3.2- Video instructions:
-Click on the image below to display the video:
-
-[![video](http://img.youtube.com/vi/5i0xVlrJc-8/0.jpg)](http://youtu.be/5i0xVlrJc-8)

--- a/hardware/doc/en/assemblyGuide.md
+++ b/hardware/doc/en/assemblyGuide.md
@@ -30,18 +30,12 @@ programs.
 
 ## About this documentation
 
-This documentation contains some help and tips to build a Poppy Humanoid
-robot. It does not replace the videos made by Inria, but complete and
-sometimes corrects or updates them.
+This documentation will guide you through the complete assembly of a Poppy Humanoid
+robot, giving your links to the instruction videos, but also pictures of all the parts to help you name them and assembly tips
 
-It contains a bit of context about Dynamixel servomotors and how to
+Get started by reading a bit about Dynamixel servomotors and how to
 assemble them ([Dynamixel Hardware](dynamixel_hardware.md)) and also how to set the
 right parameters for them ([Addressing Dynamixel](addressing_dynamixel.md)).
-
-You will also find pictures of all the parts to help you name them and assembly tips and links to the
-assembly videos. As there is no video for
-the head assembly, this doc contains a pretty complete guide for head
-assembly.
 
 Please don’t hesitate to comment and correct this documentation on the
 Poppy forum, on the [dedicated topic](https://forum.poppy-project.org/t/quickstart-assembly-and-programming-plus-some-code-examples/1228).

--- a/hardware/doc/en/legs_assembly.md
+++ b/hardware/doc/en/legs_assembly.md
@@ -6,24 +6,6 @@ There is only a video for left leg assembly. While assembling the right
 leg, be sure to put your motors symmetrical compared to the left leg.
 Also don’t forget to change the motors IDs from 12-15 to 22-25.
 
--   **[Hip](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_hip_assembly_instructions.md)**
-
--   **[Tight](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_thigh_assembly_instructions.md)**
-
--   **[Shin](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_shin_assembly_instructions.md)**
-    If you received your Poppy kit from Generation Robots, you can use
-    the custom 220mm cables instead of really short 200mm cables.
-
--   **[Right](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/right_leg_assembly_instructions.md)/[Left](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_leg_assembly_instructions.md)
-    leg assembly**
-
--   **[Pelvis](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/pelvis_assembly_instructions.md)**
-    The videos shows M2x5mm screws. Use the M2x6mm screws that you can
-    find in the Bolt-nut set BNS-10.
-
--   **[Torso and legs
-    assembly](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
-
 Motors lists:
 
 | Sub-assembly name |  Motor name |   Type  | ID |
@@ -42,3 +24,50 @@ Motors lists:
 | Right hip         |  r\_hip\_y  | MX-64AT | 23 |
 | Right thigh       |  r\_knee\_y | MX-28AT | 24 |
 | Right shin        | r\_ankle\_y | MX-28AT | 25 |
+
+-   **[Hip](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_hip_assembly_instructions.md)**
+
+-   **[Tight](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_thigh_assembly_instructions.md)**
+
+-   **[Shin](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_shin_assembly_instructions.md)**
+    If you received your Poppy kit from Generation Robots, you can use
+    the custom 220mm cables instead of really short 200mm cables.
+
+-   **[Right](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/right_leg_assembly_instructions.md)/[Left](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_leg_assembly_instructions.md)
+    leg assembly**
+
+-   **[Pelvis](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/pelvis_assembly_instructions.md)**
+    The videos shows M2x5mm screws. Use the M2x6mm screws that you can
+    find in the Bolt-nut set BNS-10.
+
+-   **[Torso and legs
+    assembly](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
+
+
+### Legs/Torso asembly
+- Preparation: 5 min
+- Assembly: 5-10 min
+
+
+#### Requirement:
+![](img/poppy_humanoid_assembly_BOM.jpg)
+
+**Sub-assemblies**
+- Legs
+- Torso
+
+**Robotis parts:**
+- 16x Bolts M2.5x4
+
+**Cables:**
+- 1x 3P 140mm
+
+**Motor configuration:**
+- 1x Alimentation 12V
+- 1x SMPS2Dynamixel
+- 1x USB2Dynamixel or USB2AX
+- A computer...
+
+
+#### <a href="http://youtu.be/5i0xVlrJc-8" target="_blank">**VIDEO INSTRUCTIONS**</a>
+

--- a/hardware/doc/en/trunk_assembly.md
+++ b/hardware/doc/en/trunk_assembly.md
@@ -2,6 +2,19 @@
 
 ![image](img/parts_chest.JPG)\
 
+Motors list:
+
+| Sub-assembly name |   Motor name   |   Type  | ID |
+|-------------------|:--------------:|:-------:|:--:|
+| Double MX64       |     abs\_y     | MX-64AT | 31 |
+| Double MX64       |     abs\_x     | MX-64AT | 32 |
+| Spine             |     abs\_z     | MX-28AT | 33 |
+| Double MX28       |     bust\_y    | MX-28AT | 34 |
+| Double MX28       |     bust\_x    | MX-28AT | 35 |
+| Chest             |     head\_z    |  AX-12A | 36 |
+| Chest             | l\_shoulder\_y | MX-28AT | 41 |
+| Chest             | r\_shoulder\_y | MX-28AT | 51 |
+
 -   **[Double
     MX64](https://github.com/poppy-project/Robotis-library/blob/master/doc/en/double_MX64_assembly.md)**
 
@@ -29,15 +42,35 @@
 
     ![image](img/screwed_SMPS.JPG)
 
-Motors list:
+### Assemble trunk and arms:
 
-| Sub-assembly name |   Motor name   |   Type  | ID |
-|-------------------|:--------------:|:-------:|:--:|
-| Double MX64       |     abs\_y     | MX-64AT | 31 |
-| Double MX64       |     abs\_x     | MX-64AT | 32 |
-| Spine             |     abs\_z     | MX-28AT | 33 |
-| Double MX28       |     bust\_y    | MX-28AT | 34 |
-| Double MX28       |     bust\_x    | MX-28AT | 35 |
-| Chest             |     head\_z    |  AX-12A | 36 |
-| Chest             | l\_shoulder\_y | MX-28AT | 41 |
-| Chest             | r\_shoulder\_y | MX-28AT | 51 |
+- Preparation: 5 min
+- Assembly: 15-20 min
+
+#### Requirements
+
+![](img/poppy_torso_assembly_BOM.jpg)
+
+**Sub-assemblies:**
+- Trunk
+- Left arm
+- Right arm
+
+**3D printed parts:**
+- Left shoulder
+- right shoulder
+
+**Cables:**
+- 2x 3P 200mm
+
+**Robotis parts:**
+- 48x Bolts M2x3
+
+**Motor configuration:**
+- 1x Alimentation 12V
+- 1x SMPS2Dynamixel
+- 1x USB2Dynamixel or USB2AX
+- A computer...
+
+
+#### <a href="http://youtu.be/uDhLIS3vxM4" target="_blank">**VIDEO INSTRUCTIONS**</a>

--- a/hardware/doc/fr/assemblage_bras.md
+++ b/hardware/doc/fr/assemblage_bras.md
@@ -2,18 +2,6 @@
 
 ![image](../img/parts_arms.JPG)\
 
--   **Avant bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_forearm_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_forearm_assembly_instructions.md)** Le design de la main a légèrement changé depuis les vidéos, mes les écrous et les vis restent les mêmes.
-
-    ![image](../img/hand_nut.JPG)
-
--   **Haut du bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_upper_arm_assembly.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_upper_arm_assembly.md)**  Branchez un cable de 200mm dans le connecteur inutilisé avant de visser les moteurs arm\_z (ids 43 et 53), parce qu'il est vraiment difficile à brancher une fois à l'intérieur de la pièce de structure.
-
--   **Haut du bras/épaule [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_upper_arm_shoulder_assembly.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_upper_arm_shoulder_assembly.md)**
-
--   **Assemblage du bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/right_arm_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/left_arm_assembly_instructions.md)**
-
--   **[Assemblage bras et torse](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
-     Pour distinguer les pièces left shoulder et right shoulder, regardez les trois points gravés dessus: le point isolé doit être en bas quand l'épaule est en position zéro (le long du moteur shoulder\_y).
 
 Liste des moteurs:
 
@@ -29,6 +17,20 @@ Liste des moteurs:
 | Haut du bras/épaule droit |Right upper arm/shoulder|  r\_shoulder\_x | MX-28AT | 52 |
 | Haut du bras droit          | Right upper arm|    r\_arm\_z   | MX-28AT | 53 |
 | Haut du bras droit          | Right upper arm|   r\_elbow\_y  | MX-28AT | 54 |
+
+
+-   **Avant bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_forearm_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_forearm_assembly_instructions.md)** Le design de la main a légèrement changé depuis les vidéos, mes les écrous et les vis restent les mêmes.
+
+    ![image](../img/hand_nut.JPG)
+
+-   **Haut du bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_upper_arm_assembly.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_upper_arm_assembly.md)**  Branchez un cable de 200mm dans le connecteur inutilisé avant de visser les moteurs arm\_z (ids 43 et 53), parce qu'il est vraiment difficile à brancher une fois à l'intérieur de la pièce de structure.
+
+-   **Haut du bras/épaule [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/right_upper_arm_shoulder_assembly.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/subassemblies/left_upper_arm_shoulder_assembly.md)**
+
+-   **Assemblage du bras [droit](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/right_arm_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-basic-arms/blob/master/doc/left_arm_assembly_instructions.md)**
+
+-   **[Assemblage bras et torse](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
+     Pour distinguer les pièces left shoulder et right shoulder, regardez les trois points gravés dessus: le point isolé doit être en bas quand l'épaule est en position zéro (le long du moteur shoulder\_y).
 
 
 

--- a/hardware/doc/fr/assemblage_jambes.md
+++ b/hardware/doc/fr/assemblage_jambes.md
@@ -4,19 +4,6 @@
 
  Il n'y a qu'une vidéo pour l'assemblage des jambes. Lors de l'assemblage de la jambe droite, assurez vous de mettre vos moteurs de façon symétrique par rapport à la jambe gauche. N'oubliez pas non plus de changer les IDs de 12 à 15 vers 22 à 25.
 
-
--   **[Hanche](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_hip_assembly_instructions.md)**
-
--   **[Cuisse](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_thigh_assembly_instructions.md)**
-
--   **[Mollet](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_shin_assembly_instructions.md)**  Si vous avez reçu votre robot de Génération Robots, vous pouvez utiliser les câbles spéciaux de 220mm au lieu des câbles de 200mm qui sont très justes.
-
--   **Assemblage de la jambe [droite](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/right_leg_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_leg_assembly_instructions.md)**
-
--   **[Pelvis](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/pelvis_assembly_instructions.md)**  La vidéo montre des vis \M2x5mm. Vous pouvez utiliser les vis M2x6mm que vous trouvez dans le set Bolt-nut set BNS-10.
-
--   **[Assemblage torse et jambes](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
-
 Listes des moteurs:
 
 | Nom du sous-assemblage   | Nom anglais    	|  Nom du moteur|   Type  	| ID 	|
@@ -35,3 +22,45 @@ Listes des moteurs:
 | Hanche droite         | Right hip         |  r\_hip\_y  | MX-64AT | 23 |
 | Cuisse droite         | Right thigh       |  r\_knee\_y | MX-28AT | 24 |
 | Mollet droit         | Right shin        | r\_ankle\_y | MX-28AT | 25 |
+
+
+-   **[Hanche](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_hip_assembly_instructions.md)**
+
+-   **[Cuisse](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_thigh_assembly_instructions.md)**
+
+-   **[Mollet](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_shin_assembly_instructions.md)**  Si vous avez reçu votre robot de Génération Robots, vous pouvez utiliser les câbles spéciaux de 220mm au lieu des câbles de 200mm qui sont très justes.
+
+-   **Assemblage de la jambe [droite](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/right_leg_assembly_instructions.md)/[gauche](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/left_leg_assembly_instructions.md)**
+
+-   **[Pelvis](https://github.com/poppy-project/Poppy-lightweight-biped-legs/blob/master/doc/subassemblies/pelvis_assembly_instructions.md)**  La vidéo montre des vis \M2x5mm. Vous pouvez utiliser les vis M2x6mm que vous trouvez dans le set Bolt-nut set BNS-10.
+
+-   **[Assemblage torse et jambes](https://github.com/poppy-project/poppy-humanoid/blob/master/hardware/doc/Poppy_Humanoid_assembly_instructions.md)**
+
+
+###  Assemblage jambes-torse
+- Preparation: 5 min
+- Assemblage: 5-10 min
+
+
+#### Matériel:
+![](../img/poppy_humanoid_assembly_BOM.jpg)
+
+**Sous-assemblages**
+- Jambes
+- Torse
+
+**Elements Robotis:**
+- 16x Vis et écrous M2.5x4
+
+**Cables:**
+- 1x 3P 140mm
+
+**Configuration des moteurs:**
+- 1x Alimentation 12V
+- 1x SMPS2Dynamixel
+- 1x USB2Dynamixel or USB2AX
+- Un ordinateur...
+
+#### <a href="http://youtu.be/5i0xVlrJc-8" target="_blank">**INSTRUCTIONS VIDEO**</a>
+
+

--- a/hardware/doc/fr/assemblage_tronc.md
+++ b/hardware/doc/fr/assemblage_tronc.md
@@ -3,6 +3,20 @@
 ![image](../img/parts_chest.JPG)\
 
 
+Liste des moteurs:
+
+| Nom du sous-assemblage   | Nom anglais    	|  Nom du moteur|   Type  	| ID 	|
+|-------------------|:--------------:|:-------:|:--:|
+| Double MX64       | Double MX64       |     abs\_y     | MX-64AT | 31 |
+| Double MX64       | Double MX64       |     abs\_x     | MX-64AT | 32 |
+| Colonne vertébrale       | Spine             |     abs\_z     | MX-28AT | 33 |
+| Double MX28       | Double MX28       |     bust\_y    | MX-28AT | 34 |
+| Double MX28       | Double MX28       |     bust\_x    | MX-28AT | 35 |
+| Poitrine       | Chest             |     head\_z    |  AX-12A | 36 |
+| Poitrine       | Chest             | l\_shoulder\_y | MX-28AT | 41 |
+| Poitrine       | Chest             | r\_shoulder\_y | MX-28AT | 51 |
+
+
 -   **[Double
     MX64](https://github.com/poppy-project/Robotis-library/blob/master/doc/en/double_MX64_assembly.md)**
 
@@ -20,15 +34,37 @@
 
 	![image](../img/screwed_SMPS.JPG)\
 
-Liste des moteurs:
 
-| Nom du sous-assemblage   | Nom anglais    	|  Nom du moteur|   Type  	| ID 	|
-|-------------------|:--------------:|:-------:|:--:|
-| Double MX64       | Double MX64       |     abs\_y     | MX-64AT | 31 |
-| Double MX64       | Double MX64       |     abs\_x     | MX-64AT | 32 |
-| Colonne vertébrale       | Spine             |     abs\_z     | MX-28AT | 33 |
-| Double MX28       | Double MX28       |     bust\_y    | MX-28AT | 34 |
-| Double MX28       | Double MX28       |     bust\_x    | MX-28AT | 35 |
-| Poitrine       | Chest             |     head\_z    |  AX-12A | 36 |
-| Poitrine       | Chest             | l\_shoulder\_y | MX-28AT | 41 |
-| Poitrine       | Chest             | r\_shoulder\_y | MX-28AT | 51 |
+###  Assemblage du tronc et des bras:
+
+- Preparation: 5 min
+- Assemblage: 15-20 min
+
+#### Matériel
+
+![](img/poppy_torso_assembly_BOM.jpg)
+
+**Sous-assemblages:**
+- Trunk
+- Left arm
+- Right arm
+
+**Pièces imprimées en 3D:**
+- Left shoulder
+- right shoulder
+
+**Cables:**
+- 2x 3P 200mm
+
+**Elements Robotis:**
+- 48x vis et écrous M2x3
+
+**Configuration des moteurs:**
+- 1x Alimentation 12V
+- 1x SMPS2Dynamixel
+- 1x USB2Dynamixel or USB2AX
+- Un ordinateur...
+
+
+#### <a href="http://youtu.be/uDhLIS3vxM4" target="_blank">**INSTRUCTIONS VIDEO**</a>
+

--- a/hardware/doc/fr/guideAssemblage.md
+++ b/hardware/doc/fr/guideAssemblage.md
@@ -24,9 +24,9 @@ Soyez donc très prudent et ne testez vos programmes que lorsque le robot est da
 
 ## A propos de cette documentation
 
-Cette documentation contient des conseils et des instructions pour construire un robot Poppy Humanoid. Elle ne remplace pas les vidéos faites par l'INRIA, mais les complète et parfois les met à jour.
+Cette documentation vous guidera tout au long de l'assemblage de votre robot Poppy Humanoid. Elle contient les liens vers les vidéos de montage, mais aussi des images pour vous aider à identifier les différentes pièces et des conseils.
 
-Elle contient une brève description du matériel Dynamixel et de la façon de le monter ([Materiel Dynamixel](materiel_dynamixel.md)), ainsi qu'un guide de paramétrage des moteurs ([Adressage des Dynamixel](adressage_dynamixel.md)).
+Commencez par vous familiariser avec le matériel Dynamixel et de la façon de le monter ([Materiel Dynamixel](materiel_dynamixel.md)), ainsi qu'un guide de paramétrage des moteurs ([Adressage des Dynamixel](adressage_dynamixel.md)).
 
 N'hésitez pas à améliorer cette documentation et à signaler les erreurs sur ce [sujet](https://forum.poppy-project.org/t/quickstart-assembly-and-programming-plus-some-code-examples/1228) du forum Poppy.
 
@@ -39,7 +39,7 @@ N'hésitez pas à améliorer cette documentation et à signaler les erreurs sur 
 - [**Assemblage des jambes >>**](assemblage_jambes.md)
 - [**Assemblage de la tête >>**](assemblage_tete.md)
 
-# Liens utiles {#documentation-links}
+# Liens utiles
 
 ## Instructions d'assemblage
 


### PR DESCRIPTION
Pour garder la cohérence FR-en, poppy_humanoid_assembly_instruction ne contient plus que des liens vers les 'pages d'accueil' en et fr. A voir si tu veux copier la page d'accueil en dans poppy_humanoid_assembly_instruction ... 

Les liens entre les différentes pages sont à vérifier mais sinon normalement tout est bon.